### PR TITLE
Installation clarifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ Start the application
 
 Before you can use the demo please open `http://<your_application_name>/setup` and configure the application. The demo overview will be accessible at `http://<your_application_name>`. Please note, if process.env.PORT is not set the applications runs on port 5000.
 
+If you are running the demo locally please remember that Twilio needs a publically-accessible address for webhooks, and the setup process registers these with Twilio. As such, you'll need to run something like ngrok instead of just hitting http://localhost:5000/. As you get new addresses from ngrok you'll need to also rerun the setup process to register the updated address with Twilio.
+
 **Note:** On Google Chrome a secure HTTPS connection is required to do phone calls via WebRTC. Use a tunnel that supports HTTPS such as ngrok, which can forward the traffic to your webserver.
 
 # Contributions

--- a/controllers/setup-phone-number.js
+++ b/controllers/setup-phone-number.js
@@ -17,6 +17,7 @@ module.exports.update = function (req, res) {
 	}).then(phoneNumber => {
 		res.status(200).end()
 	}).catch(error => {
+		console.log('Setup Failure: Error setting up URLs for voice and SMS channels.')
 		res.status(500).send(res.convertErrorToJSON(error))
 	})
 

--- a/controllers/setup.js
+++ b/controllers/setup.js
@@ -27,6 +27,7 @@ module.exports.update = function (req, res) {
 
 			module.exports.createOrUpdateApplication(config, req, function (err, application) {
 				if (err) {
+					console.log('Setup Failure: Error setting up Twilio client application.')
 					callback(err)
 				} else {
 					config.twilio.applicationSid = application.sid
@@ -39,6 +40,7 @@ module.exports.update = function (req, res) {
 
 			module.exports.updateMessagingService(req, config, function (err) {
 				if (err) {
+					console.log('Setup Failure: Error updating messaging service.')
 					callback(err)
 				} else {
 					callback(null, config)
@@ -49,6 +51,7 @@ module.exports.update = function (req, res) {
 
 			module.exports.syncQueues(config, function (err) {
 				if (err) {
+					console.log('Setup Failure: Error establishing queues.')
 					callback(err)
 				} else {
 					callback(null, config)
@@ -80,6 +83,7 @@ module.exports.update = function (req, res) {
 			module.exports.createOrUpdateWorkflow(workflow, function (err, workflow) {
 
 				if (err) {
+					console.log('Setup Failure: Error setting up workflows.')
 					callback(err)
 				} else {
 					config.twilio.workflowSid = workflow.sid
@@ -124,6 +128,7 @@ module.exports.syncQueues = function (config, callback) {
 
 		module.exports.createOrUpdateQueue(queueForSync, function (err, queueFromApi) {
 			if (err) {
+				console.log('Queue Setup Failure: Problem setting up specific queue.')
 				callback(err)
 			} else {
 				queue.taskQueueSid = queueFromApi.sid


### PR DESCRIPTION
As I rushed to set this up locally to get something working for our call center in S Houston in response to Harvey, I ran into a couple issues that I was able to work through, but thought might be helpful to document to help future people.

- Added a quick note in the README about how this needs to work when running locally (need ngrok). It's obvious why ngrok is necessary for local work, but in my rush I didn't realize it for a little while.
- Because all of the setup processes happen asynchronously, and because the error messages if you haven't set up a chat service, for example, may not be clearly related to the problem, I added simple log statements on errors to help identify the part of the application that was failing. 

No big changes here, just helpful tools to save people some time later on. (Sorry just realized I didn't rebase, but hopefully these changes are simple enough to just absorb!)